### PR TITLE
Feature: 리프레시 토큰을 이용한 액세스 토큰 재발급 API 구현

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,12 @@ const app = express();
 
 await connectDB();
 
-app.use(cors());
+app.use(
+  cors({
+    origin: "http://localhost:5173",
+    credentials: true,
+  }),
+);
 app.use(express.json());
 app.use(cookieParser());
 

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -7,6 +7,7 @@ const projectsRouter = express.Router();
 projectsRouter.get("/", async (req, res) => {
   try {
     const projects = await Project.find();
+    projects.title = req.body;
     res.status(200).json(projects);
   } catch (error) {
     console.error("프로젝트 전체 조회 중 에러 발생", error);
@@ -36,7 +37,7 @@ projectsRouter.post("/", async (req, res) => {
     const currentDate = new Date();
 
     const newProject = await Project.create({
-      title: currentDate,
+      title: req.body.title,
       ownerId,
       createdAt: currentDate,
       updatedAt: currentDate,
@@ -64,6 +65,28 @@ projectsRouter.delete("/:projectId", async (req, res) => {
   } catch (error) {
     console.error("프로젝트 삭제 중 에러 발생", error);
     res.status(500).json({ message: "서버 에러로 데이터를 삭제하지 못했습니다." });
+  }
+});
+
+projectsRouter.patch("/:projectId", async (req, res) => {
+  const { title } = req.body;
+  const { projectId } = req.params;
+
+  if (!title) {
+    return res.status(400).json({ message: "프로젝트 제목이 필요합니다." });
+  }
+
+  try {
+    const updatedProject = await Project.findByIdAndUpdate(projectId, { title }, { new: true });
+
+    if (!updatedProject) {
+      return res.status(404).json({ message: "프로젝트가 없습니다." });
+    }
+
+    return res.status(200).json(updatedProject);
+  } catch (err) {
+    console.error("프로젝트 수정 실패:", err);
+    return res.status(500).json({ message: "서버 에러 입니다." });
   }
 });
 

--- a/routes/user.js
+++ b/routes/user.js
@@ -37,6 +37,7 @@ async function getKakaoUserInfo(accessToken) {
     headers: {
       "Authorization": `Bearer ${accessToken}`,
       "Content-Type": "application/json",
+      "credentials": "include",
     },
   });
 
@@ -70,8 +71,8 @@ router.post("/login", async (req, res) => {
       user = await User.create({ kakaoId });
     }
 
-    const accessToken = generateAccessToken({ userId: user.kakaoId });
-    const refreshToken = generateRefreshToken({ userId: user.kakaoId });
+    const accessToken = generateAccessToken({ userId: user.kakaoId, tokenType: "access" });
+    const refreshToken = generateRefreshToken({ userId: user.kakaoId, tokenType: "refresh" });
 
     res
       .cookie("refreshToken", refreshToken, {
@@ -84,7 +85,8 @@ router.post("/login", async (req, res) => {
       .json({
         message: "로그인 성공",
         token: accessToken,
-        user: { id: user._id },
+        userID: user._id,
+        refreshToken: refreshToken,
       });
   } catch (err) {
     console.error("로그인 처리 실패:", err.message);

--- a/utills/utills.js
+++ b/utills/utills.js
@@ -1,9 +1,13 @@
 import jwt from "jsonwebtoken";
 
 export function generateAccessToken(payload) {
-  return jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: "10m" });
+  return jwt.sign({ ...payload, tokenType: "access" }, process.env.JWT_SECRET, {
+    expiresIn: "10m",
+  });
 }
 
 export function generateRefreshToken(payload) {
-  return jwt.sign(payload, process.env.JWT_REFRESH_SECRET, { expiresIn: "7d" });
+  return jwt.sign({ ...payload, tokenType: "refresh" }, process.env.JWT_REFRESH_SECRET, {
+    expiresIn: "7d",
+  });
 }


### PR DESCRIPTION
## #️⃣ Issue Number #9

## 📝 요약(Summary)
- /refresh 경로에 POST API 구현
- 클라이언트 쿠키에서 refreshToken을 받아 JWT 검증 수행
- 유효한 토큰일 경우 DB에서 사용자 조회 후 accessToken 새로 발급
- 유저가 없거나 토큰이 유효하지 않을 경우 403 또는 404 응답 처리


## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
- [x] 코드 컨벤션에 맞게 작성했습니다.
