### PR TITLE
Refactor: 도미노 CRUD 통합 및 모델/스키마 책임 분리

### DIFF
--- a/Models/DominosSchema.js
+++ b/Models/DominosSchema.js
@@ -1,86 +1,30 @@
 import mongoose, { Schema } from "mongoose";
 
-import { OBJECT_NAMES, COLLIDERS, GROUP_NAMES, TYPE } from "../constants/index.js";
+import objectInfoSchema from "./ObjectInfoSchema.js";
 
-const objectInfoSchema = new Schema({
-  objectName: {
-    type: String,
-    enum: OBJECT_NAMES,
-    required: true,
-  },
-  thumbnail: {
-    type: String,
-    required: true,
-  },
-  model: {
-    type: String,
-    required: true,
-  },
-  sound: {
-    type: String,
-    required: true,
-  },
-  colliders: {
-    type: String,
-    enum: COLLIDERS,
-    required: true,
-  },
-  type: {
-    type: String,
-    enum: TYPE,
-    required: true,
-  },
-  groupName: {
-    type: String,
-    enum: GROUP_NAMES,
-    required: true,
-  },
-});
-
-const projectSchema = new Schema({
-  title: {
-    type: String,
-  },
-  ownerId: {
-    type: String,
-    required: true,
-  },
-  createdAt: {
-    type: Date,
-    required: true,
-  },
-  updatedAt: {
-    type: Date,
-    required: true,
-  },
-});
-
-const DominosSchema = new Schema({
-  projectId: {
-    type: String,
-    required: false,
-  },
+const dominosSchema = new Schema({
+  projectId: { type: String },
   position: {
     type: [Number],
     required: true,
-    validate: {
-      validator: (arr) => arr.length === 3,
-    },
+    validate: { validator: (arr) => arr.length === 3 },
   },
   rotation: {
     type: [Number],
     required: true,
-    validate: {
-      validator: (arr) => arr.length === 3,
-    },
+    validate: { validator: (arr) => arr.length === 3 },
   },
-  opacity: { type: Number, required: true },
-  color: { type: String },
+  opacity: {
+    type: Number,
+    required: true,
+  },
+  color: {
+    type: String,
+  },
   objectInfo: {
     type: objectInfoSchema,
     required: true,
   },
 });
 
-export const DominoModel = mongoose.model("DominoModel", DominosSchema);
-export const ProjectModel = mongoose.model("ProjectModel", projectSchema);
+export const DominoModel = mongoose.model("DominoModel", dominosSchema);

--- a/Models/DominosSchema.js
+++ b/Models/DominosSchema.js
@@ -82,5 +82,5 @@ const DominosSchema = new Schema({
   },
 });
 
-export const Domino = mongoose.model("Domino", DominosSchema);
-export const Project = mongoose.model("Project", projectSchema);
+export const DominoModel = mongoose.model("DominoModel", DominosSchema);
+export const ProjectModel = mongoose.model("ProjectModel", projectSchema);

--- a/Models/ObjectInfoSchema.js
+++ b/Models/ObjectInfoSchema.js
@@ -1,0 +1,40 @@
+import { Schema } from "mongoose";
+
+import { OBJECT_NAMES, COLLIDERS, GROUP_NAMES, TYPE } from "../constants/index.js";
+
+const objectInfoSchema = new Schema({
+  objectName: {
+    type: String,
+    enum: OBJECT_NAMES,
+    required: true,
+  },
+  thumbnail: {
+    type: String,
+    required: true,
+  },
+  model: {
+    type: String,
+    required: true,
+  },
+  sound: {
+    type: String,
+    required: true,
+  },
+  colliders: {
+    type: String,
+    enum: COLLIDERS,
+    required: true,
+  },
+  type: {
+    type: String,
+    enum: TYPE,
+    required: true,
+  },
+  groupName: {
+    type: String,
+    enum: GROUP_NAMES,
+    required: true,
+  },
+});
+
+export default objectInfoSchema;

--- a/Models/ProjectSchema.js
+++ b/Models/ProjectSchema.js
@@ -1,0 +1,18 @@
+import mongoose, { Schema } from "mongoose";
+
+const projectSchema = new Schema(
+  {
+    title: {
+      type: String,
+    },
+    ownerId: {
+      type: String,
+      required: true,
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+export const ProjectModel = mongoose.model("ProjectModel", projectSchema);

--- a/routes/dominos.js
+++ b/routes/dominos.js
@@ -19,43 +19,29 @@ dominosRouter.get("/:projectId", async (req, res) => {
 dominosRouter.post("/:projectId", async (req, res) => {
   try {
     const { projectId } = req.params;
-    const { deleteDominoId, dominos } = req.body;
-
-    if (deleteDominoId) {
-      const deleteResult = await Domino.deleteOne({ _id: deleteDominoId, projectId });
-
-      if (deleteResult.deletedCount === 0) {
-        return res.status(404).json({ message: "삭제할 도미노를 찾을 수 없습니다." });
-      }
-
-      const dominosAfterDelete = await Domino.find({ projectId }).lean();
-      return res.status(200).json(dominosAfterDelete);
-    }
+    const { dominos } = req.body;
 
     if (!Array.isArray(dominos)) {
       return res.status(400).json({ message: "유효하지 않은 요청입니다." });
     }
 
+    await Domino.deleteMany({ projectId });
+
     if (dominos.length === 0) {
-      const deleteResult = await Domino.deleteMany({ projectId });
-
-      if (deleteResult.deletedCount === 0) {
-        return res.status(404).json({ message: "삭제할 도미노가 없습니다." });
-      }
-
       return res.status(200).json([]);
     }
 
-    const newDominos = dominos.filter((item) => !item._id).map((item) => ({ ...item, projectId }));
+    const newDominos = dominos.map((item) => ({
+      ...item,
+      projectId,
+    }));
 
-    if (newDominos.length > 0) {
-      await Domino.insertMany(newDominos);
-    }
+    await Domino.insertMany(newDominos);
 
     const finalDominos = await Domino.find({ projectId }).lean();
     return res.status(200).json(finalDominos);
   } catch (error) {
-    console.error("도미노 처리 중 에러 발생", error);
+    console.error("도미노 처리 중 에러 발생:", error);
     return res.status(500).json({ message: "서버 에러로 도미노 작업을 처리하지 못했습니다." });
   }
 });

--- a/routes/dominos.js
+++ b/routes/dominos.js
@@ -1,13 +1,13 @@
 import express from "express";
 
-import { Domino } from "../Models/DominosSchema.js";
+import { DominoModel } from "../Models/DominosSchema.js";
 
 const dominosRouter = express.Router();
 
 dominosRouter.get("/:projectId", async (req, res) => {
   try {
     const { projectId } = req.params;
-    const dominos = await Domino.find({ projectId }).lean();
+    const dominos = await DominoModel.find({ projectId }).lean();
 
     return res.status(200).json(dominos);
   } catch (error) {
@@ -25,7 +25,7 @@ dominosRouter.post("/:projectId", async (req, res) => {
       return res.status(400).json({ message: "유효하지 않은 요청입니다." });
     }
 
-    await Domino.deleteMany({ projectId });
+    await DominoModel.deleteMany({ projectId });
 
     if (dominos.length === 0) {
       return res.status(200).json([]);
@@ -36,9 +36,9 @@ dominosRouter.post("/:projectId", async (req, res) => {
       projectId,
     }));
 
-    await Domino.insertMany(newDominos);
+    await DominoModel.insertMany(newDominos);
 
-    const finalDominos = await Domino.find({ projectId }).lean();
+    const finalDominos = await DominoModel.find({ projectId }).lean();
     return res.status(200).json(finalDominos);
   } catch (error) {
     console.error("도미노 처리 중 에러 발생:", error);

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -1,6 +1,7 @@
 import express from "express";
 
-import { ProjectModel, DominoModel } from "../Models/DominosSchema.js";
+import { ProjectModel } from "../Models/ProjectSchema.js";
+import { DominoModel } from "../Models/DominosSchema.js";
 
 const projectsRouter = express.Router();
 

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -1,12 +1,12 @@
 import express from "express";
 
-import { Project, Domino } from "../Models/DominosSchema.js";
+import { ProjectModel, DominoModel } from "../Models/DominosSchema.js";
 
 const projectsRouter = express.Router();
 
 projectsRouter.get("/", async (req, res) => {
   try {
-    const projects = await Project.find();
+    const projects = await ProjectModel.find();
     res.status(200).json(projects);
   } catch (error) {
     console.error("프로젝트 전체 조회 중 에러 발생", error);
@@ -17,7 +17,7 @@ projectsRouter.get("/", async (req, res) => {
 projectsRouter.get("/:projectId", async (req, res) => {
   try {
     const { projectId } = req.params;
-    const project = await Project.findOne({ _id: projectId });
+    const project = await ProjectModel.findOne({ _id: projectId });
 
     if (!project) {
       return res.status(404).json({ message: "일치하는 프로젝트가 없습니다." });
@@ -35,7 +35,7 @@ projectsRouter.post("/", async (req, res) => {
     const ownerId = "1234"; // 임시처리
     const currentDate = new Date();
 
-    const newProject = await Project.create({
+    const newProject = await ProjectModel.create({
       title: currentDate,
       ownerId,
       createdAt: currentDate,
@@ -53,8 +53,8 @@ projectsRouter.delete("/:projectId", async (req, res) => {
   try {
     const { projectId } = req.params;
 
-    await Project.deleteOne({ _id: projectId });
-    const deletedDominos = await Domino.deleteMany({ projectId });
+    await ProjectModel.deleteOne({ _id: projectId });
+    const deletedDominos = await DominoModel.deleteMany({ projectId });
 
     res.status(200).json({
       message: "프로젝트 및 연결된 도미노가 성공적으로 삭제되었습니다.",


### PR DESCRIPTION
## #️⃣ Issue Number #11

## 📝 요약(Summary)
도미노 POST API의 처리 방식을 다음과 같이 리팩토링했습니다.

기존에는 `deleteDominoId`가 있는 경우 단일 삭제, 
`dominos` 배열이 빈 경우 전체 삭제, `_id`가 없는 항목만을 `insert`하는 등 분기 기반의 처리 로직을 따랐지만,
이번 수정에서는 단일 POST 요청으로 도미노 목록 전체를 덮어씌우는 방식으로 통합했습니다.

이 방식은 클라이언트가 각 도미노의 `_id`를 유지하고 있다는 전제하에 동작하며,
MongoDB가 `_id`가 존재하는 도큐먼트는 새로 생성하지 않는 특성을 활용해
데이터 일관성을 유지하면서도 로직을 단순화할 수 있었습니다.

또한, 도미노 및 프로젝트 모델의 스키마 책임을 각 파일로 분리하여 가독성과 유지보수성을 개선했습니다.

## 💬 공유사항 to 리뷰어
- 도미노의 전체 교체 방식이 운영 상 안전한지 검토 부탁드립니다.
- 이 방식의 장점은 클라이언트가 유지 중인 `_id` 값이 그대로 반영되므로, 업데이트시 구조를 단순하게 유지할 수 있다는 점입니다.

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
- [x] 코드 컨벤션에 맞게 작성했습니다.