### PR TITLE
Feature: 리프레시 토큰을 이용한 액세스 토큰 재발급 API 구현

### DIFF
--- a/Models/UserInfoSchema.js
+++ b/Models/UserInfoSchema.js
@@ -6,6 +6,8 @@ const userInfoSchema = new Schema({
     required: true,
     unique: true,
   },
+  refreshToken: { type: String, default: null },
+  accessToken: { type: String, default: null },
 });
 
 const User = mongoose.model("user", userInfoSchema);

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 import express from "express";
 import cors from "cors";
 import dotenv from "dotenv";
-import cookieParser from "cookie-parser";
 
 import connectDB from "./config/db.js";
 import dominosRouter from "./routes/dominos.js";
@@ -23,7 +22,6 @@ app.use(
   }),
 );
 app.use(express.json());
-app.use(cookieParser());
 
 app.get("/", (req, res) => {
   res.send("hello");

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "body-parser": "^2.2.0",
-        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
@@ -875,25 +874,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/cookie-parser": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
-      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "0.7.2",
-        "cookie-signature": "1.0.6"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/cookie-parser/node_modules/cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
-      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   },
   "dependencies": {
     "body-parser": "^2.2.0",
-    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",


### PR DESCRIPTION
## #️⃣ Issue Number #9 

## 📝 요약(Summary)
- 카카오 로그인 처리
- 카카오 ID 기반으로 사용자 조회
- 신규 사용자일 경우 회원 생성
- JWT 기반 accessToken, refreshToken 발급 및 저장
- 로그인 성공 시 사용자 정보와 토큰을 응답
- 클라이언트에서 받은 accessToken을 이용해 카카오 API에 unlink 요청
- 성공 시 DB에서 해당 토큰을 가진 사용자 정보 삭제


## 주요 구현 사항:
- 클라이언트로부터 전달받은 kakaoId를 바탕으로 사용자 존재 여부 확인
- 사용자가 존재하지 않으면 새로 생성
- 사용자가 존재할 경우 기존 사용자 정보에 JWT 토큰 갱신 후 저장
- 클라이언트에 응답으로 다음 정보를 전달: accessToken, refreshToken (JWT)

- 클라이언트로부터 받은 accessToken을 사용해 카카오에 unlink 요청 전송
- 키카오 서버에서 정상 응답이 오면, 해당 accessToken을 가진 사용자 정보를 MongoDB에서 삭제


## ✅ PR Checklist
- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [X] 코드 컨벤션에 맞게 작성했습니다.