### PR TITLE
Feat: 도미노 동기화 버그 수정 및 방 제어 기능 개선 

### DIFF
--- a/config/socket.js
+++ b/config/socket.js
@@ -13,8 +13,17 @@ const socketSetup = (server) => {
 
     socket.on("join project room", ({ projectId }) => {
       const room = `project:${projectId}`;
-      socket.join(room);
+      const roomInfo = io.sockets.adapter.rooms.get(room);
+      const numberOfUsers = roomInfo ? roomInfo.size : 0;
 
+      if (numberOfUsers >= 5) {
+        socket.emit("room full", {
+          message: "방 인원 수가 초과되어 입장할 수 없습니다.",
+        });
+        return;
+      }
+
+      socket.join(room);
       socket.data.projectId = projectId;
 
       io.to(room).emit("user joined", {

--- a/config/socket.js
+++ b/config/socket.js
@@ -58,6 +58,10 @@ const socketSetup = (server) => {
       io.to(`project:${projectId}`).emit("other cursor clear", { userID });
     });
 
+    socket.on("clear domino", ({ projectId }) => {
+      io.to(`project:${projectId}`).emit("domino cleared", { projectId });
+    });
+
     socket.on("disconnect", () => {
       const projectId = socket.data.projectId;
       if (projectId) {

--- a/config/socket.js
+++ b/config/socket.js
@@ -3,7 +3,7 @@ import { Server } from "socket.io";
 const socketSetup = (server) => {
   const io = new Server(server, {
     cors: {
-      origin: "http://localhost:5173",
+      origin: process.env.FRONT_END_URL,
       methods: ["GET", "POST"],
     },
   });

--- a/config/socket.js
+++ b/config/socket.js
@@ -62,6 +62,10 @@ const socketSetup = (server) => {
       io.to(`project:${projectId}`).emit("domino cleared", { projectId });
     });
 
+    socket.on("reset domino", ({ projectId }) => {
+      io.to(`project:${projectId}`).emit("reset domino");
+    });
+
     socket.on("disconnect", () => {
       const projectId = socket.data.projectId;
       if (projectId) {

--- a/config/socket.js
+++ b/config/socket.js
@@ -45,12 +45,17 @@ const socketSetup = (server) => {
       });
     });
 
+    socket.on("clear cursor", ({ projectId }) => {
+      io.to(`project:${projectId}`).emit("other cursor clear", { userID });
+    });
+
     socket.on("disconnect", () => {
       const projectId = socket.data.projectId;
       if (projectId) {
         const room = `project:${projectId}`;
         io.to(room).emit("user left", {
           message: `${userNickname}님이 방을 떠났습니다.`,
+          userID,
         });
       }
     });

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ socketSetup(server);
 
 app.use(
   cors({
-    origin: "http://localhost:5173",
+    origin: process.env.FRONT_END_URL,
     credentials: true,
     allowedHeaders: ["Content-Type", "Authorization", "refresh-token"],
   }),


### PR DESCRIPTION
## #️⃣ Issue Number #20 

## 📝 요약(Summary)
도미노 시뮬레이션 및 방 제어 관련 소켓 이벤트 처리를 개선하고, 도미노 초기화 및 리셋 기능 동기화를 구현하였습니다.

주요 변경 사항:
- 방 인원 초과 시 안내 토스트 표시 및 /projects 페이지로 이동
- ESC 키 또는 사용자 퇴장 시 해당 사용자 커서 제거 처리 (user left, other cursor clear)
- 내 커서는 userID로 식별하여 제외
- 도미노 초기화 시 서버에 clear domino 이벤트 전송
- 도미노 리셋 시 서버에 reset domino 이벤트 전송 추가
- 환경변수(FRONT_END_URL)를 사용해 소켓 서버 origin 설정 하드코딩 제거

## 💬 공유사항 to 리뷰어
- reset domino 이벤트 관련 네이밍이나 구조 개선 포인트가 있다면 피드백 부탁드립니다.
- userID 기반 커서 제거 로직이 복잡하지 않은지, 혹은 더 나은 방식이 있을지 검토해주시면 감사하겠습니다.

## ✅ PR Checklist
- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [X] 코드 컨벤션에 맞게 작성했습니다.