### PR TITLE
Fix: MongoDB 도큐먼트 저장 시 동일한 _id가 중복 생성되는 현상 수정

### DIFF
--- a/Models/ObjectInfoSchema.js
+++ b/Models/ObjectInfoSchema.js
@@ -34,6 +34,10 @@ const objectInfoSchema = new Schema({
     enum: GROUP_NAMES,
     required: true,
   },
+  title: {
+    type: String,
+    required: true,
+  },
 });
 
 export default objectInfoSchema;

--- a/constants/index.js
+++ b/constants/index.js
@@ -13,7 +13,7 @@ export const OBJECT_NAMES = [
   "soccerFootball",
   "lightbulb",
   "bumper",
-  "car",
+  "steelBall",
 ];
 
 export const COLLIDERS = ["cuboid", "trimesh", "ball", "hull"];


### PR DESCRIPTION
## #️⃣ Issue Number #26 

## 📝 요약(Summary)
React에서 `_id`를 key로 사용할 때, MongoDB의 bulkWrite로 도큐먼트를 추가하는 과정에서 `_id`가 중복 발급되는 문제가 발생했습니다.
이로 인해 다수의 오브젝트를 렌더링할 경우 React에서 `key` 충돌 경고가 출력되고 렌더링 문제가 발생할 수 있어,
해당 문제를 방지하기 위해 중복되지 않는 `_id`를 보장하도록 로직을 개선했습니다.

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 코드 컨벤션에 맞게 작성했습니다.