### PR TITLE
Refactor: JWT 만료 시간 연장 및 요청 body 크기 제한 확장

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,8 @@ app.use(
   }),
 );
 
-app.use(express.json());
+app.use(express.json({ limit: "10mb" }));
+app.use(express.urlencoded({ extended: true, limit: "10mb" }));
 
 app.get("/", (req, res) => {
   res.send("hello");

--- a/utills/utills.js
+++ b/utills/utills.js
@@ -4,7 +4,7 @@ import User from "../Models/UserInfoSchema.js";
 
 export const generateAccessToken = (payload) =>
   jwt.sign({ ...payload, tokenType: "access" }, process.env.JWT_SECRET, {
-    expiresIn: "10m",
+    expiresIn: "6h",
   });
 
 export const generateRefreshToken = (payload) =>


### PR DESCRIPTION
## 📝 요약(Summary)
- JWT 만료 시간을 기존 1시간에서 6시간으로 연장했습니다.
- 지속적인 인증 유지가 필요한 클라이언트 환경을 고려해 만료 주기를 늘렸습니다.
- 요청 body 크기 제한을 기본 100KB → 10MB로 확장했습니다.
- 초당 다량의 데이터(배열 등)를 전송하는 환경에서 413 Payload Too Large 오류를 방지하기 위함입니다.

## 💬 공유사항 to 리뷰어
- express.json, express.urlencoded 설정이 서버 전체 성능에 미치는 영향은 크지 않지만, 혹시 보안상 우려되는 부분이 있다면 논의 부탁드립니다.

## ✅ PR Checklist
- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [X] 코드 컨벤션에 맞게 작성했습니다.