### PR TITLE
Feat: 도미노 업데이트 socket 전파 시 sendUser(userID) 정보 포함

### DIFF
--- a/config/socket.js
+++ b/config/socket.js
@@ -51,6 +51,7 @@ const socketSetup = (server) => {
       io.to(room).emit("domino update", {
         userNickname,
         dominos,
+        sendUser: userID,
       });
     });
 


### PR DESCRIPTION
## #️⃣ Issue Number #30

## 📝 요약(Summary)
도미노 업데이트 이벤트를 전파할 때, 이벤트를 보낸 유저의 ID 정보를 함께 전달하도록 수정했습니다.

### 🔧 변경 사항
- `socket.on("update domino")` 핸들러 내에서 `io.to(room).emit(...)` 호출 시, `sendUser` 필드를 추가로 포함
- 클라이언트는 해당 값을 기반으로 본인이 보낸 이벤트를 무시하도록 처리함

직접 브로드캐스트 구조를 바꾸지 않고도, 프론트에서의 중복 렌더링을 제어할 수 있도록 하기 위한 목적입니다.

## 💬 공유사항 to 리뷰어
- 없습니다.

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 코드 컨벤션에 맞게 작성했습니다.