### PR TITLE
Feature: 사용자 정보 수정 API 구현

### DIFF
--- a/Models/UserInfoSchema.js
+++ b/Models/UserInfoSchema.js
@@ -8,6 +8,7 @@ const userInfoSchema = new Schema({
   },
   refreshToken: { type: String, default: null },
   accessToken: { type: String, default: null },
+  isTutorialUser: { type: Boolean, default: true },
 });
 
 const User = mongoose.model("user", userInfoSchema);


### PR DESCRIPTION
## #️⃣ Issue Number #33

## 📝 요약(Summary)
사용자의 튜토리얼 상태(isTutorialUser)를 클라이언트에서 변경할 수 있도록,
PATCH /users/me/tutorial API를 새롭게 추가하였습니다.
클라이언트는 인증된 사용자의 kakaoId를 기반으로 해당 필드만 수정할 수 있으며,
변경된 사용자 정보는 응답으로 반환되어 클라이언트 상태와의 동기화를 쉽게 할 수 있도록 설계하였습니다.

## 💬 공유사항 to 리뷰어
현재는 `isTutorialUser` 필드만 수정 가능하도록 제한되어 있어 이후 확장성이 필요할 경우 스키마를 확장하는 방향도 고려할 수 있습니다.

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 코드 컨벤션에 맞게 작성했습니다.