### PR TITLE
Refactor: io.to → socket.to로 변경하여 방 내부 이벤트 브로드캐스트 방식 적용

### DIFF
--- a/config/socket.js
+++ b/config/socket.js
@@ -26,7 +26,7 @@ const socketSetup = (server) => {
       socket.join(room);
       socket.data.projectId = projectId;
 
-      io.to(room).emit("user joined", {
+      socket.to(room).emit("user joined", {
         message: `${userNickname}님이 방에 입장했습니다.`,
       });
     });
@@ -35,7 +35,7 @@ const socketSetup = (server) => {
       "update cursor position",
       ({ projectId, objectInfo, position, selectedColor, rotationY }) => {
         const room = `project:${projectId}`;
-        io.to(room).emit("cursor position update", {
+        socket.to(room).emit("cursor position update", {
           userNickname,
           objectInfo,
           position,
@@ -48,23 +48,22 @@ const socketSetup = (server) => {
 
     socket.on("update domino", ({ projectId, dominos }) => {
       const room = `project:${projectId}`;
-      io.to(room).emit("domino update", {
+      socket.to(room).emit("domino update", {
         userNickname,
         dominos,
-        sendUser: userID,
       });
     });
 
     socket.on("clear cursor", ({ projectId }) => {
-      io.to(`project:${projectId}`).emit("other cursor clear", { userID });
+      socket.to(`project:${projectId}`).emit("other cursor clear", { userID });
     });
 
     socket.on("clear domino", ({ projectId }) => {
-      io.to(`project:${projectId}`).emit("domino cleared", { projectId });
+      socket.to(`project:${projectId}`).emit("domino cleared", { projectId });
     });
 
     socket.on("reset domino", ({ projectId }) => {
-      io.to(`project:${projectId}`).emit("reset domino");
+      socket.to(`project:${projectId}`).emit("reset domino");
     });
 
     socket.on("disconnect", () => {


### PR DESCRIPTION
## #️⃣ Issue Number #32

---

## 📝 요약(Summary)

기존에는 `io.to(room).emit(...)`을 사용하여 방에 있는 모든 사용자(본인 포함)에게 이벤트를 전파하고 있었습니다.  
이번 PR에서는 `socket.to(room).emit(...)`으로 리팩토링하여 **본인을 제외한 같은 방의 사용자에게만 이벤트를 전송**하도록 수정했습니다.

이를 통해 클라이언트 측에서 불필요하게 자신의 이벤트를 필터링하는 조건문을 제거할 수 있으며,  
전체 실시간 처리 흐름의 안정성과 효율성을 개선합니다.

---

## 📸 스크린샷 (선택)
없음

---

## 💬 공유사항 to 리뷰어

- `disconnect` 이벤트는 `socket`이 끊긴 상태에서는 `socket.to(...)`를 사용할 수 없기 때문에 기존의 `io.to(...)`를 유지했습니다.
- 클라이언트에서도 `userID !== myUserID` 같은 조건이 제거되었는지 확인 부탁드립니다.
- 네이밍이나 구조에 대해 더 나은 의견 있으시면 공유해주세요.

---

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (브라우저 2개로 실시간 테스트 확인)
- [x] 코드 컨벤션에 맞게 작성했습니다.