### PR TITLE
Fix: 로그인 시 사용자 튜토리얼 상태가 항상 true로 반환되는 현상 수정

### DIFF
--- a/routes/user.js
+++ b/routes/user.js
@@ -87,7 +87,7 @@ router.post("/login", async (req, res) => {
       refreshToken: refreshToken,
       userNickname,
       kakaoAccessToken: kakaoAccessToken,
-      isTutorialUser: true,
+      isTutorialUser: user.isTutorialUser,
     });
   } catch (err) {
     console.error("로그인 처리 실패:", err.message);


### PR DESCRIPTION
## #️⃣ Issue Number #36

## 📝 요약(Summary)
로그인 시 사용자 정보 중 `isTutorialUser` 값이 항상 `true`로 전달되던 문제를 수정했습니다.
기존에는 사용자 생성 여부와 관계없이 응답에서 해당 필드를 무조건 `true`로 리턴하고 있었기 때문에, 
이미 튜토리얼을 완료한 사용자도 매번 튜토리얼 상태로 처리되는 버그가 발생했습니다.
이를 DB에 저장된 사용자 정보의 값을 기준으로 응답하도록 수정하였습니다.

## 💬 공유사항 to 리뷰어
추가로 로그인 응답 구조 관련해서 더 필요한 필드가 있다면 함께 논의해보면 좋을 것 같습니다.

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 코드 컨벤션에 맞게 작성했습니다.