### PR TITLE
Fix: 리셋 시 도미노 중복/삭제 오류 해결을 위한 전체 덮어쓰기 API 도입

### DIFF
--- a/config/socket.js
+++ b/config/socket.js
@@ -62,8 +62,8 @@ const socketSetup = (server) => {
       socket.to(`project:${projectId}`).emit("domino cleared", { projectId });
     });
 
-    socket.on("reset domino", ({ projectId }) => {
-      socket.to(`project:${projectId}`).emit("reset domino");
+    socket.on("reset domino", ({ projectId, dominos }) => {
+      io.to(`project:${projectId}`).emit("reset domino", { dominos });
     });
 
     socket.on("disconnect", () => {

--- a/routes/dominos.js
+++ b/routes/dominos.js
@@ -23,6 +23,7 @@ dominosRouter.post("/:projectId", async (req, res) => {
   try {
     const { projectId } = req.params;
     const { dominos } = req.body;
+
     if (!Array.isArray(dominos)) {
       return res.status(400).json({ message: "dominos'는 배열이어야 합니다" });
     }
@@ -70,6 +71,31 @@ dominosRouter.post("/:projectId", async (req, res) => {
   } catch (error) {
     console.error("도미노 처리 중 에러 발생:", error);
     return res.status(500).json({ message: "서버 에러로 도미노 저장에 실패했습니다." });
+  }
+});
+
+dominosRouter.post("/:projectId/overwrite", async (req, res) => {
+  try {
+    const { projectId } = req.params;
+    const { dominos } = req.body;
+
+    if (!Array.isArray(dominos)) {
+      return res.status(400).json({ message: "'dominos'는 배열이어야 합니다." });
+    }
+
+    await DominoModel.deleteMany({ projectId });
+
+    const dominosToInsert = dominos.map((domino) => ({
+      ...domino,
+      projectId,
+    }));
+
+    const insertedDominos = await DominoModel.insertMany(dominosToInsert);
+
+    return res.status(200).json(insertedDominos);
+  } catch (error) {
+    console.error("도미노 덮어쓰기 중 에러:", error);
+    return res.status(500).json({ message: "도미노 덮어쓰기에 실패했습니다." });
   }
 });
 


### PR DESCRIPTION
## #️⃣ Issue Number #41 

## 📝 요약(Summary)
기존에는 클라이언트에서 도미노 상태를 전송하면 `_id` 유무에 따라 
`replaceOne` 혹은 `insertOne`을 수행하는 방식으로 도미노 상태를 업데이트하고 있었습니다. 
그러나 이 방식은 리셋 시 클라이언트 간 도미노 상태가 일치하지 않거나, 도미노가 중복되거나 사라지는 등의 문제를 일으킬 수 있었습니다.

이러한 문제를 해결하기 위해, 특정 시점의 도미노 배열 전체를 기준으로 덮어쓰는 전용 overwrite API를 새로 추가했습니다.
이 API는 기존 데이터를 전부 삭제하고 전달받은 배열로 다시 삽입하며, 
소켓 이벤트를 통해 모든 클라이언트가 동일한 기준 상태를 유지할 수 있도록 합니다.


## 💬 공유사항 to 리뷰어
- overwrite API는 기존 `update` 방식과 분리하여 작성했습니다. 

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 코드 컨벤션에 맞게 작성했습니다.