### PR TITLE
Fix: 신규 사용자 로그인 시 프리셋 프로젝트 및 도미노 자동 생성 누락 문제 해결

### DIFF
--- a/routes/user.js
+++ b/routes/user.js
@@ -105,6 +105,7 @@ router.post("/login", async (req, res) => {
 
     if (!user) {
       user = await User.create({ kakaoId, userNickname, accessToken, refreshToken });
+      await createPresetProjects(kakaoId);
     } else {
       user.accessToken = accessToken;
       user.refreshToken = refreshToken;


### PR DESCRIPTION
## 📝 요약(Summary)
신규 사용자가 카카오로 회원가입할 때, 기본 프리셋 프로젝트와 도미노가 자동으로 생성되도록 로직을 추가했습니다.
기존에는 유저만 생성되고 프리셋 프로젝트가 누락되는 문제가 있었으나,
`createPresetProjects` 함수 호출을 회원가입 후 처리 로직에 추가하여 이를 해결했습니다.

## 📸 스크린샷 (선택)
<img width="1470" alt="스크린샷 2025-06-18 오후 10 25 01" src="https://github.com/user-attachments/assets/752081f4-188a-405b-a657-e88e0b4dce24" />

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 코드 컨벤션에 맞게 작성했습니다.