### PR TITLE
Refactor: 클라이언트에서 전달된 _id 기반으로 도미노 저장 로직 리팩토링

### DIFF
--- a/.github/workflows/backend_deploy.yaml
+++ b/.github/workflows/backend_deploy.yaml
@@ -39,6 +39,12 @@ jobs:
             
             npm install
             
-            pm2 restart all
+            if pm2 list | grep -q domido-backend; then
+              pm2 restart domido-backend
+            else
+              pm2 start npm --name domido-backend -- start
+            fi
+
+            pm2 save
           EOF
           

--- a/Models/DominosSchema.ts
+++ b/Models/DominosSchema.ts
@@ -3,6 +3,7 @@ import mongoose, { Schema } from "mongoose";
 import objectInfoSchema from "./ObjectInfoSchema";
 
 const dominosSchema = new Schema({
+  _id: { type: String, required: true },
   projectId: { type: String },
   position: {
     type: [Number],


### PR DESCRIPTION
## 📝 요약(Summary)
클라이언트에서 도미노 생성 시 `_id`를 포함하도록 수정함에 따라, 서버에서는 `insertOne`이 아닌 `replaceOne + upsert: true` 방식으로 일괄 처리하도록 저장 로직을 리팩토링했습니다.

- 클라이언트가 모든 도미노에 `_id`를 포함하여 전달
- 서버는 `_id` 유무 분기 없이 `replaceOne + upsert: true`로 처리
- 도미노 삭제는 기존과 동일하게 clientId 기준으로 비교하여 수행
- 전체적으로 코드가 간결해지고, 서버 로직 통일로 유지보수성 향상

## 📸 스크린샷 (선택)
없음

## 💬 공유사항 to 리뷰어
- 클라이언트에서 `_id`를 생성하도록 변경한 부분과 맞물려 있는 서버 리팩토링입니다.
- `replaceOne + upsert: true` 방식이 예상대로 동작하는지, 혹은 `updateOne`이 더 적합할지에 대한 의견도 주세요.

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 코드 컨벤션에 맞게 작성했습니다.